### PR TITLE
expose container format name and major brand

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -334,6 +334,19 @@ const char *ff_get_color_range_name(enum AVColorRange val) {
     return av_color_range_name(val);
 }
 
+const char *ff_get_input_format_name(AVFormatContext* fmt_ctx) {
+    return fmt_ctx->iformat ? fmt_ctx->iformat->name : NULL;
+}
+
+const char *ff_get_major_brand(AVFormatContext* fmt_ctx) {
+    AVDictionaryEntry *tag = NULL;
+    tag = av_dict_get(fmt_ctx->metadata, "major_brand", NULL, 0);
+
+    if (tag) return tag->value;
+
+    return NULL;
+}
+
 double ff_get_media_duration(AVFormatContext* fmt_ctx) {
     if (fmt_ctx->duration != AV_NOPTS_VALUE && fmt_ctx->duration > 0) {
         return fmt_ctx->duration / (double)AV_TIME_BASE;

--- a/funcs.json
+++ b/funcs.json
@@ -218,6 +218,8 @@
     ["ff_get_color_range_name", "string", ["number"], { "nullable": true }],
     ["ff_get_media_duration", "number", ["number"], { "async": true }],
     ["ff_get_timecode", "string", ["number"], { "async": true, "nullable": true }],
+    ["ff_get_input_format_name", "string", ["number"], { "nullable": true }],
+    ["ff_get_major_brand", "string", ["number"], { "nullable": true }],
 
     ["calloc", "number", ["number", "number"]],
     ["close", "number", ["number"]],


### PR DESCRIPTION
리뷰어: @jyeokchoi @sojeong-v6x 
미디어 파일의 container 정보를 얻어오기 위해, format name과 major brand를 expose 합니다.