### PR TITLE
fix merge-integer logic of ff_init_demuxer_file

### DIFF
--- a/post.in.js
+++ b/post.in.js
@@ -1296,7 +1296,7 @@ function ff_init_demuxer_file(filename, fmt) {
             outStream.time_base_den = AVStream_time_base_den(inStream);
 
             const durationlo = AVStream_duration(inStream) >>> 0;
-            const durationhi = AVStream_durationhi(inStream) >>> 0;
+            const durationhi = AVStream_durationhi(inStream);
             outStream.duration_time_base = durationlo + (durationhi*0x100000000);
             outStream.duration = outStream.duration_time_base * outStream.time_base_num / outStream.time_base_den;
             outStream.rotation = avformat_get_rotation(inStream)


### PR DESCRIPTION
* @jyeokchoi @hyeongin-v6x 
* 이전에 lo, hi 모두 양수화하도록 했었는데, 생각해보니 원래 값이 int64_t이라 hi는 양수화하면 안 되네욥..
* mergeInteger 와 동일하게 lo, hi 조립하도록 수정합니다.
* 요것도 0.0.12에 반영되면 좋을 것 같습니다.
